### PR TITLE
feat: add to_value and from_value functions.

### DIFF
--- a/src/drisl.rs
+++ b/src/drisl.rs
@@ -19,7 +19,11 @@ pub use self::de::from_reader;
 #[doc(inline)]
 pub use self::de::from_slice;
 #[doc(inline)]
+pub use self::de::from_value;
+#[doc(inline)]
 pub use self::error::{DecodeError, EncodeError};
+#[doc(inline)]
+pub use self::ser::to_value;
 #[doc(inline)]
 pub use self::ser::to_vec;
 #[doc(inline)]
@@ -38,9 +42,6 @@ mod tests {
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
     struct TupleStruct(String, i32, u64);
-
-    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-    struct UnitStruct;
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
     struct Struct<'a> {

--- a/src/drisl/de.rs
+++ b/src/drisl/de.rs
@@ -3,7 +3,7 @@ use core::{
     convert::{Infallible, TryFrom},
     marker::PhantomData,
 };
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use cbor4ii::core::{
     dec::{self, Decode},
@@ -13,7 +13,7 @@ use cbor4ii::core::{
 };
 use serde::{
     Deserialize,
-    de::{self, Visitor},
+    de::{self, Error as _, IntoDeserializer, Visitor},
 };
 
 use super::{
@@ -85,6 +85,14 @@ where
     let mut deserializer = Deserializer::from_reader(reader);
     let value = serde::Deserialize::deserialize(&mut deserializer)?;
     deserializer.end()?;
+    Ok(value)
+}
+
+/// Decodes a Rust type from a dynamic DRISL [`Value`][super::Value].
+pub fn from_value<T: de::DeserializeOwned>(
+    value: super::Value,
+) -> Result<T, serde::de::value::Error> {
+    let value = <T as serde::Deserialize>::deserialize(ValueDeserializer::new(value))?;
     Ok(value)
 }
 
@@ -803,6 +811,375 @@ where
         use serde::Deserializer;
 
         self.de.deserialize_map(visitor)
+    }
+}
+
+/// Deserializer that can deserialize a Rust type from a DRISL [`Value`][super::Value].
+pub struct ValueDeserializer {
+    value: super::Value,
+}
+
+impl ValueDeserializer {
+    pub fn new(value: super::Value) -> Self {
+        Self { value }
+    }
+}
+
+impl<'de> de::IntoDeserializer<'de, serde::de::value::Error> for super::Value {
+    type Deserializer = ValueDeserializer;
+    fn into_deserializer(self) -> Self::Deserializer {
+        ValueDeserializer::new(self)
+    }
+}
+
+macro_rules! value_deserialize_type {
+    ( @ $t:ty , $variant:ident, $name:ident , $visit:ident ) => {
+        #[inline]
+        fn $name<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where V: Visitor<'de>
+        {
+            use serde::de::Error;
+            let super::Value::$variant(v) = self.value else {
+                return Err(Self::Error::custom(concat!("expected ", stringify!($t))));
+            };
+            visitor.$visit(v as $t)
+        }
+    };
+    ( $( $t:ty , $variant:ident , $name:ident , $visit:ident );* $( ; )? ) => {
+        $(
+            value_deserialize_type!(@ $t, $variant, $name, $visit);
+        )*
+    };
+}
+
+impl<'de> serde::Deserializer<'de> for ValueDeserializer {
+    type Error = serde::de::value::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            super::Value::Integer(v) => visitor.visit_i128(v),
+            super::Value::Bytes(v) => visitor.visit_byte_buf(v),
+            super::Value::Float(v) => visitor.visit_f64(v),
+            super::Value::Text(v) => visitor.visit_string(v),
+            super::Value::Bool(v) => visitor.visit_bool(v),
+            super::Value::Null => visitor.visit_none(),
+            super::Value::Cid(cid) => visitor.visit_newtype_struct(ValueCidDeserializer(cid)),
+            super::Value::Array(values) => {
+                visitor.visit_seq(de::value::SeqDeserializer::new(values.into_iter()))
+            }
+            super::Value::Map(map) => {
+                visitor.visit_map(de::value::MapDeserializer::new(map.into_iter()))
+            }
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let super::Value::Null = self.value {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self.value.into_deserializer())
+        }
+    }
+
+    value_deserialize_type! {
+        f32, Float, deserialize_f32, visit_f32;
+        f64, Float, deserialize_f64, visit_f64;
+        u8, Integer, deserialize_u8, visit_u8;
+        u16, Integer, deserialize_u16, visit_u16;
+        u32, Integer, deserialize_u32, visit_u32;
+        u64, Integer, deserialize_u64, visit_u64;
+        i8, Integer, deserialize_i8, visit_i8;
+        i16, Integer, deserialize_i16, visit_i16;
+        i32, Integer, deserialize_i32, visit_i32;
+        i64, Integer, deserialize_i64, visit_i64;
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let super::Value::Map(map) = self.value else {
+            return Err(de::value::Error::custom("expected map"));
+        };
+        visitor.visit_map(ValueMapAccess {
+            map,
+            staged_value: None,
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let super::Value::Array(seq) = self.value else {
+            return Err(de::value::Error::custom("expected map"));
+        };
+        visitor.visit_seq(ValueSeqAccess {
+            seq: seq.into_iter(),
+        })
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let super::Value::Null = self.value {
+            visitor.visit_unit()
+        } else {
+            Err(de::value::Error::custom(
+                "expected null while deserializing unit",
+            ))
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if name == CID_SERDE_PRIVATE_IDENTIFIER {
+            if let super::Value::Cid(cid) = self.value {
+                visitor.visit_newtype_struct(ValueCidDeserializer(cid))
+            } else {
+                Err(de::value::Error::custom("expect Cid"))
+            }
+        } else {
+            visitor.visit_newtype_struct(self)
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(ValueEnumAccess { value: self.value })
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool byte_buf char identifier ignored_any str
+        string unit bytes
+    }
+}
+
+struct ValueMapAccess {
+    map: BTreeMap<String, super::Value>,
+    staged_value: Option<super::Value>,
+}
+
+impl<'de> de::MapAccess<'de> for ValueMapAccess {
+    type Error = de::value::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        let Some((key, value)) = self.map.pop_first() else {
+            return Ok(None);
+        };
+        self.staged_value = Some(value);
+        Ok(Some(
+            seed.deserialize(de::value::StringDeserializer::new(key))?,
+        ))
+    }
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let value = self.staged_value.take().unwrap();
+        seed.deserialize(value.into_deserializer())
+    }
+}
+
+struct ValueSeqAccess {
+    seq: std::vec::IntoIter<super::Value>,
+}
+
+impl<'de> de::SeqAccess<'de> for ValueSeqAccess {
+    type Error = de::value::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        let Some(value) = self.seq.next() else {
+            return Ok(None);
+        };
+        Ok(Some(seed.deserialize(value.into_deserializer())?))
+    }
+}
+
+struct ValueEnumAccess {
+    value: super::Value,
+}
+
+impl<'de> de::EnumAccess<'de> for ValueEnumAccess {
+    type Error = de::value::Error;
+    type Variant = ValueEnumAccess;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let variant = match &self.value {
+            super::Value::Text(s) => s.clone(),
+            super::Value::Map(m) if m.len() == 1 => m.keys().next().unwrap().clone(),
+            _ => {
+                return Err(de::value::Error::custom(
+                    "Expected string enum discriminant or map with single string enum discriminant as key",
+                ));
+            }
+        };
+        let variant = seed.deserialize(de::value::StringDeserializer::new(variant))?;
+        Ok((variant, self))
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for ValueEnumAccess {
+    type Error = de::value::Error;
+
+    #[inline]
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        if !matches!(self.value, super::Value::Text(_)) {
+            return Err(de::value::Error::custom("expected string enum variant"));
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        if let super::Value::Map(m) = self.value {
+            let value = m.into_values().next().unwrap();
+            seed.deserialize(ValueDeserializer::new(value))
+        } else {
+            Err(de::value::Error::custom(
+                "expected map with single enum variant key and enum variant value",
+            ))
+        }
+    }
+
+    #[inline]
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        use serde::Deserializer;
+
+        if let super::Value::Map(m) = self.value {
+            let value = m.into_values().next().unwrap();
+            ValueDeserializer::new(value).deserialize_tuple(len, visitor)
+        } else {
+            Err(de::value::Error::custom(
+                "expected map with single enum variant key and enum variant value",
+            ))
+        }
+    }
+
+    #[inline]
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        use de::Deserializer;
+        if let super::Value::Map(m) = self.value {
+            let value = m.into_values().next().unwrap();
+            ValueDeserializer::new(value).deserialize_map(visitor)
+        } else {
+            Err(de::value::Error::custom(
+                "expected map with single enum variant key and enum variant value",
+            ))
+        }
+    }
+}
+
+struct ValueCidDeserializer(crate::cid::Cid);
+
+impl<'de> serde::de::Deserializer<'de> for ValueCidDeserializer {
+    type Error = serde::de::value::Error;
+
+    fn deserialize_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_bytes(visitor)
+    }
+
+    #[inline]
+    fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_byte_buf(self.0.as_bytes().to_vec())
+    }
+
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        name: &str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        if name == CID_SERDE_PRIVATE_IDENTIFIER {
+            self.deserialize_bytes(visitor)
+        } else {
+            Err(de::Error::custom([
+                "This deserializer must not be called on newtype structs other than one named `",
+                CID_SERDE_PRIVATE_IDENTIFIER,
+                "`"
+            ].concat()))
+        }
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool byte_buf char enum f32 f64 i8 i16 i32 i64 identifier ignored_any map option seq str
+        string struct tuple tuple_struct u8 u16 u32 u64 unit unit_struct
     }
 }
 

--- a/src/drisl/ser.rs
+++ b/src/drisl/ser.rs
@@ -1,5 +1,9 @@
 //! Serialization.
-use std::{collections::TryReserveError, string::ToString, vec::Vec};
+use std::{
+    collections::{BTreeMap, TryReserveError},
+    string::ToString,
+    vec::Vec,
+};
 
 pub use cbor4ii::core::utils::{BufWriter, IoWriter};
 use cbor4ii::core::{
@@ -30,6 +34,14 @@ where
 {
     let mut serializer = Serializer::new(IoWriter::new(writer));
     value.serialize(&mut serializer)
+}
+
+/// Serializes a Rust type to a DRISL [`Value`][super::Value].
+pub fn to_value<T>(source: T) -> Result<super::Value, EncodeError<TryReserveError>>
+where
+    T: Serialize,
+{
+    source.serialize(&mut ValueSerializer)
 }
 
 /// A structure for serializing Rust values to DRISL.
@@ -531,6 +543,518 @@ where
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
         self.end()
+    }
+}
+
+/// Serializer that can serialize a Rust type to a DRISL [`Value`][super::Value].
+pub struct ValueSerializer;
+
+impl<'a> serde::Serializer for &'a mut ValueSerializer {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+
+    type SerializeSeq = ValueSerializerSeq<'a>;
+    type SerializeTuple = ValueSerializerSeq<'a>;
+    type SerializeTupleStruct = ValueSerializerSeq<'a>;
+    type SerializeTupleVariant = ValueSerializerTupleVariant<'a>;
+    type SerializeMap = ValueSerializerMap<'a>;
+    type SerializeStruct = ValueSerializerMap<'a>;
+    type SerializeStructVariant = ValueSerializerStructVariant<'a>;
+
+    #[inline]
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Bool(v))
+    }
+    #[inline]
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Integer(v as i128))
+    }
+    #[inline]
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.serialize_f64(v.into())
+    }
+    #[inline]
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        // In DRISL only finite floats are supported.
+        if !v.is_finite() {
+            Err(EncodeError::Msg(
+                "Float must be a finite number, not Infinity or NaN".into(),
+            ))
+        } else {
+            Ok(super::Value::Float(v))
+        }
+    }
+
+    #[inline]
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Text(v.into()))
+    }
+
+    #[inline]
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Text(v.into()))
+    }
+
+    #[inline]
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Bytes(v.into()))
+    }
+
+    #[inline]
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Null)
+    }
+
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    #[inline]
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Null)
+    }
+
+    #[inline]
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        if name == CID_SERDE_PRIVATE_IDENTIFIER {
+            let mut bytes = BufWriter::new(Vec::new());
+            value.serialize(&mut CidSerializer(&mut Serializer::new(&mut bytes)))?;
+            Ok(super::Value::Bytes(bytes.into_inner()))
+        } else {
+            value.serialize(self)
+        }
+    }
+
+    #[inline]
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut map = BTreeMap::new();
+        map.insert(variant.to_string(), value.serialize(self)?);
+        Ok(super::Value::Map(map))
+    }
+
+    #[inline]
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(ValueSerializerSeq {
+            seq: Vec::with_capacity(len.unwrap_or(0)),
+            serializer: self,
+        })
+    }
+
+    #[inline]
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    #[inline]
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_tuple(len)
+    }
+
+    #[inline]
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(ValueSerializerTupleVariant {
+            variant_name: variant,
+            seq: Vec::with_capacity(len),
+            serializer: self,
+        })
+    }
+
+    #[inline]
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(ValueSerializerMap {
+            serializer: self,
+            map: BTreeMap::new(),
+            staged_key: None,
+        })
+    }
+
+    #[inline]
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(ValueSerializerMap {
+            serializer: self,
+            map: BTreeMap::new(),
+            staged_key: None,
+        })
+    }
+
+    #[inline]
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(ValueSerializerStructVariant {
+            map: BTreeMap::new(),
+            serializer: self,
+            variant_name: variant,
+        })
+    }
+}
+
+pub struct ValueSerializerSeq<'a> {
+    serializer: &'a mut ValueSerializer,
+    seq: Vec<super::Value>,
+}
+
+impl serde::ser::SerializeSeq for ValueSerializerSeq<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.seq.push(value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Array(self.seq))
+    }
+}
+
+impl serde::ser::SerializeTuple for ValueSerializerSeq<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.seq.push(value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Array(self.seq))
+    }
+}
+
+impl serde::ser::SerializeTupleStruct for ValueSerializerSeq<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.seq.push(value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Array(self.seq))
+    }
+}
+
+pub struct ValueSerializerTupleVariant<'a> {
+    variant_name: &'static str,
+    serializer: &'a mut ValueSerializer,
+    seq: Vec<super::Value>,
+}
+
+impl serde::ser::SerializeTupleVariant for ValueSerializerTupleVariant<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.seq.push(value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut map = BTreeMap::new();
+        map.insert(self.variant_name.into(), super::Value::Array(self.seq));
+        Ok(super::Value::Map(map))
+    }
+}
+
+pub struct ValueSerializerMap<'a> {
+    serializer: &'a mut ValueSerializer,
+    map: BTreeMap<String, super::Value>,
+    staged_key: Option<String>,
+}
+impl serde::ser::SerializeMap for ValueSerializerMap<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.staged_key = Some(key.serialize(StringKeySerializer)?);
+        Ok(())
+    }
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let key = self.staged_key.take().unwrap();
+        self.map
+            .insert(key, value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Map(self.map))
+    }
+}
+impl serde::ser::SerializeStruct for ValueSerializerMap<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.map
+            .insert(key.into(), value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(super::Value::Map(self.map))
+    }
+}
+
+pub struct ValueSerializerStructVariant<'a> {
+    variant_name: &'static str,
+    serializer: &'a mut ValueSerializer,
+    map: BTreeMap<String, super::Value>,
+}
+impl serde::ser::SerializeStructVariant for ValueSerializerStructVariant<'_> {
+    type Ok = super::Value;
+    type Error = EncodeError<TryReserveError>;
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.map
+            .insert(key.into(), value.serialize(&mut *self.serializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut wrapper = BTreeMap::new();
+        wrapper.insert(self.variant_name.into(), super::Value::Map(self.map));
+        Ok(super::Value::Map(wrapper))
+    }
+}
+
+macro_rules! error_for_primitive_serialize_impls {
+    ($error:expr, $($impl_tys:ty, $impls:ident),+ $(,)?) => {
+        $(
+            fn $impls(self, _value: $impl_tys) -> Result<Self::Ok, Self::Error> {
+                Err(ser::Error::custom($error))
+            }
+        )*
+    }
+}
+
+static STRING_KEY_ERROR: &str = "invalid key type, expected string";
+struct StringKeySerializer;
+impl ser::Serializer for StringKeySerializer {
+    type Ok = String;
+    type Error = EncodeError<TryReserveError>;
+
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+
+    error_for_primitive_serialize_impls!(
+        STRING_KEY_ERROR,
+        bool,
+        serialize_bool,
+        i8,
+        serialize_i8,
+        i16,
+        serialize_i16,
+        i32,
+        serialize_i32,
+        i64,
+        serialize_i64,
+        u8,
+        serialize_u8,
+        u16,
+        serialize_u16,
+        u32,
+        serialize_u32,
+        u64,
+        serialize_u64,
+        f32,
+        serialize_f32,
+        f64,
+        serialize_f64,
+        char,
+        serialize_char,
+        &[u8],
+        serialize_bytes,
+    );
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_some<T: ?Sized + ser::Serialize>(
+        self,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_unit_struct(self, _name: &str) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        _variant: &str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        _variant: &str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        _variant: &str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_struct(
+        self,
+        _name: &str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &str,
+        _variant_index: u32,
+        _variant: &str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(ser::Error::custom(STRING_KEY_ERROR))
     }
 }
 

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -670,3 +670,69 @@ fn test_default_values() {
         }
     }
 }
+
+#[test]
+fn test_from_value() {
+    #[derive(Deserialize, Debug, PartialEq, Eq)]
+    struct Data1 {
+        a: u32,
+        b: String,
+        c: Data2,
+    }
+
+    #[derive(Deserialize, Debug, PartialEq, Eq)]
+    enum Data2 {
+        Info,
+        Stuff { count: i16 },
+    }
+
+    let value = Value::Map({
+        let mut m = BTreeMap::new();
+        m.insert("a".into(), 5.into());
+        m.insert("b".into(), "mary".to_string().into());
+        m.insert("c".into(), Value::Text("Info".into()));
+        m
+    });
+
+    assert_eq!(
+        dasl::drisl::from_value::<Data1>(value),
+        Ok(Data1 {
+            a: 5,
+            b: "mary".into(),
+            c: Data2::Info,
+        })
+    );
+
+    let value = Value::Map({
+        let mut m = BTreeMap::new();
+        m.insert("a".into(), 5.into());
+        m.insert("b".into(), "brown".to_string().into());
+        m.insert(
+            "c".into(),
+            Value::Map({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "Stuff".to_string(),
+                    Value::Map({
+                        let mut m = BTreeMap::new();
+                        m.insert("count".to_string(), 33.into());
+                        m
+                    }),
+                );
+                m
+            }),
+        );
+        m
+    });
+
+    dbg!(&value);
+
+    assert_eq!(
+        dasl::drisl::from_value::<Data1>(value),
+        Ok(Data1 {
+            a: 5,
+            b: "brown".into(),
+            c: Data2::Stuff { count: 33 },
+        })
+    );
+}

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -85,11 +85,3 @@ fn test_variable_length_array_error() {
     let err = value.unwrap_err();
     assert!(matches!(err, DecodeError::IndefiniteSize), "{err:?}");
 }
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-enum Bar {
-    Empty,
-    Number(i32),
-    Flag(String, bool),
-    Point { x: i32, y: i32 },
-}

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -241,3 +241,63 @@ fn test_struct_variant_canonical() {
         b"\xa1\x64Data\xa3\x61a\x01\x61b\x02\x63abc\x03"
     )
 }
+
+#[test]
+fn test_to_value() {
+    use dasl::drisl::Value;
+
+    #[derive(Serialize)]
+    struct Data1 {
+        a: u32,
+        b: String,
+        c: Data2,
+    }
+
+    #[derive(Serialize)]
+    enum Data2 {
+        Info,
+        Stuff { count: i16 },
+    }
+
+    let data = Data1 {
+        a: 17,
+        b: "John".into(),
+        c: Data2::Stuff { count: 3 },
+    };
+    let value = dasl::drisl::to_value(&data).unwrap();
+    let Value::Map(map) = value else {
+        panic!("Invalid type");
+    };
+
+    assert_eq!(map.get("a"), Some(&Value::Integer(17 as _)));
+    assert_eq!(map.get("b"), Some(&Value::Text("John".into())));
+    assert_eq!(
+        map.get("c"),
+        Some(&Value::Map({
+            let mut m = BTreeMap::new();
+            m.insert(
+                "Stuff".into(),
+                Value::Map({
+                    let mut m = BTreeMap::new();
+                    m.insert("count".into(), Value::Integer(3 as _));
+                    m
+                }),
+            );
+            m
+        }))
+    );
+
+    let data = Data1 {
+        a: 41,
+        b: "Charlie".into(),
+        c: Data2::Info,
+    };
+    let value = dasl::drisl::to_value(&data).unwrap();
+    let Value::Map(map) = value else {
+        panic!("Invalid type");
+    };
+
+    assert_eq!(map.get("a"), Some(&Value::Integer(41 as _)));
+    assert_eq!(map.get("b"), Some(&Value::Text("Charlie".into())));
+    assert_eq!(map.get("c"), Some(&Value::Text("Info".into())));
+}


### PR DESCRIPTION
## Description

Adds `to_value()` and `from_value()` functions along with corresponding `ValueSerializer` and `ValueDeserializer` structs, which can be used to convert between a Rust struct that implements `Serialize`/`Deserialize` and a `dasl::drisl::Value`.

## Breaking Changes

None

## Notes & open questions

My use-case was wanting to have a Rust wrapper type that contained a DRISL `Value` in it and could be deserialized without needing to know the details of the inner type.

But then later I would need to take that `Value` and deserialize it into a specific Rust type. Letting you deserialize directly from the `Value` saves a round-trip through the CBOR encoding.

I added a couple small test-cases, but they are far from exhaustive.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
