### PR TITLE
feat: implement `Hash` for `Cid`.

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -21,7 +21,7 @@ const DATA_LEN: usize = PREFIX_LEN + HASH_LEN as usize;
 const HASH_CODE_SHA2_256: u8 = 0x12;
 const HASH_CODE_BLAKE3: u8 = 0x1e;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
 pub struct Cid {
     // - 1 byte CID version
     // - 1 byte Codec


### PR DESCRIPTION
## Description

Simply derives `Hash` for `Cid`.

## Breaking Changes

None.

## Notes & open questions

Let's use `Cid` as `HashMap` key. :wink: 

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
